### PR TITLE
feat: drop read-package-json-fast

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   "main": "./dist/commonjs/main.js",
   "types": "./dist/commonjs/main.d.ts",
   "dependencies": {
-    "read-package-json-fast": "^3.0.2",
     "walk-up-path": "^3.0.1"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import {walkUp} from 'walk-up-path';
 import {resolve} from 'node:path';
-import {stat} from 'node:fs/promises';
-import rpj from 'read-package-json-fast';
+import {stat, readFile} from 'node:fs/promises';
 
 /**
  * Determines if a file exists or not
@@ -51,5 +50,10 @@ export async function findPackage(cwd: string): Promise<Package | null> {
     return null;
   }
 
-  return rpj(packagePath);
+  try {
+    const source = await readFile(packagePath, {encoding: 'utf8'});
+    return JSON.parse(source);
+  } catch (_err) {
+    return null;
+  }
 }

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -61,4 +61,13 @@ test('findPackage', async (t) => {
 
     assert.equal(result!.name, 'simple-package');
   });
+
+  await t.test('null for non-existent packages', async () => {
+    assert.equal(await findPackage('/'), null);
+  });
+
+  await t.test('null for invalid package.json', async () => {
+    const fixturePath = joinPath(currentDir, 'test/fixtures/broken-package');
+    assert.equal(await findPackage(fixturePath), null);
+  });
 });

--- a/test/fixtures/broken-package/package.json
+++ b/test/fixtures/broken-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "broken-package",
+  "private": true,
+  "version": "1.0.0",
+  "description": "I'm totally missing a closing brace",


### PR DESCRIPTION
This removes the `read-package-json-fast` dependency since we don't actually need the normalisation it provides.

It is soon being merged into npm's CLI package too, meaning we will have a rather heavy dependency for what's basically the task of reading a file.

Makes sense to drop it.

Fixes #1 