### PR TITLE
feat: add synchronous methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ parameter:
 await findPackage(process.cwd()); // Returns the JSON of the package if found
 ```
 
+Synchronous methods also exist:
+
+```ts
+findPackageSync(process.cwd()); // returns the package
+
+findPackagePathSync(process.cwd()); // returns the package path
+```
+
 ## License
 
 MIT

--- a/src/test/main_test.ts
+++ b/src/test/main_test.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert';
 import {test} from 'node:test';
 import {fileURLToPath} from 'node:url';
 import {join as joinPath} from 'node:path';
-import {findPackage, findPackagePath} from '../main.js';
+import {
+  findPackage,
+  findPackagePath,
+  findPackageSync,
+  findPackagePathSync
+} from '../main.js';
 
 const currentDir = fileURLToPath(new URL('../../', import.meta.url));
 const rootPackagePath = joinPath(currentDir, 'package.json');
@@ -69,5 +74,25 @@ test('findPackage', async (t) => {
   await t.test('null for invalid package.json', async () => {
     const fixturePath = joinPath(currentDir, 'test/fixtures/broken-package');
     assert.equal(await findPackage(fixturePath), null);
+  });
+});
+
+test('findPackagePathSync', async (t) => {
+  await t.test('finds package in cwd', () => {
+    const fixturePath = joinPath(currentDir, 'test/fixtures/simple-package');
+    const packagePath = joinPath(
+      currentDir,
+      'test/fixtures/simple-package/package.json'
+    );
+    assert.equal(findPackagePathSync(fixturePath), packagePath);
+  });
+});
+
+test('findPackageSync', async (t) => {
+  await t.test('finds package in simple tree', () => {
+    const fixturePath = joinPath(currentDir, 'test/fixtures/simple-package');
+    const result = findPackageSync(fixturePath);
+
+    assert.equal(result!.name, 'simple-package');
   });
 });


### PR DESCRIPTION
This adds synchronous equivalents to each of the exposed functions.

Unfortunately, we have to duplicate code a little but this will come in useful in some sync-only places like ESLint.